### PR TITLE
Add optional version change argument to publish-releasenotes-on-slack

### DIFF
--- a/src/commands/publish-releasenotes-on-slack.ts
+++ b/src/commands/publish-releasenotes-on-slack.ts
@@ -20,12 +20,18 @@ To use this command, an incoming webhook for slack is required and must be confi
 OPTIONS
 
 --mode    sets the package mode [dotnet, node, python] (default: node)
+--addVersionChange    adds version changes to the changelog, it can be used several times
 `;
 // DOC: see above
 
 export async function run(...args): Promise<boolean> {
   const argv = yargsParser(args, { alias: { help: ['h'] }, default: { mode: DEFAULT_MODE } });
   const mode = argv.mode;
+  let additionalVersionChanges;
+  if (argv.addVersionChange != null) {
+    additionalVersionChanges = Array.isArray(argv.addVersionChange) ? argv.addVersionChange : [argv.addVersionChange];
+  }
+
   setupGit();
 
   await printInfo(mode);
@@ -33,7 +39,7 @@ export async function run(...args): Promise<boolean> {
   annotatedSh('git config user.name');
   annotatedSh('git config user.email');
 
-  const releasenotes = await getReleaseAnnouncement(mode);
+  const releasenotes = await getReleaseAnnouncement(mode, additionalVersionChanges);
 
   await sendSlackMessage(releasenotes);
 
@@ -46,6 +52,10 @@ export function getShortDoc(): string {
 
 export function printHelp(): void {
   console.log(`Usage: ci_tools ${COMMAND_NAME} [--mode <MODE>]`);
+  console.log(`Usage: ci_tools ${COMMAND_NAME} [--addVersionChange <NPM_PACKAGE_NAME>]`);
+  console.log(
+    `Usage: ci_tools ${COMMAND_NAME} [--addVersionChange <NPM_PACKAGE_NAME>] [--addVersionChange <NPM_PACKAGE_NAME>] ...`
+  );
   console.log('');
   console.log(DOC.trim());
 }

--- a/src/git/git.ts
+++ b/src/git/git.ts
@@ -128,6 +128,18 @@ export function isGitHubRemote(): boolean {
   return matchData != null;
 }
 
+export function getStartCommit(startDate: string, branch: string): string {
+  const commitHash = sh(`git rev-list -1 --before="${startDate}" "${branch}"`);
+
+  return commitHash.trim();
+}
+
+export function getDiffFromStartToCurrentHead(startCommit: string, filename: string): string {
+  const diff = sh(`git diff ${startCommit} HEAD -- "${filename}"`);
+
+  return diff.trim();
+}
+
 function getGitBranchFromGit(): string {
   const outputLines = sh('git branch')
     .trim()


### PR DESCRIPTION
## Changes

1. Add --addVersionChange argument to getReleaseAnnouncement
2. Add package updates to release announcement

Example:
```
*@process-engine/ci_tools v3.1.0-alpha.10 was released!*

The new version includes the following changes:

- Betarelease v3.1.0 beta.2
- Increase total amount of retries with npm view before failing ensureVersionIsAvailable
- 🔒 Fix security vulnerabilities
- ✨ Add python and .NET support to create-release-announcement
- ✨ Add --release-channel-(name|number) option for get-version
- 🐛 Don't use dev dependencies in runtime code
- ✨ Add support for Python projects
- ✨ Add new command to replace dist-tags with real versions

The following dependencies were updated:

- node-fetch was updated from ^2.6.0 to ^2.6.1
,- mocha was updated from ^6.1.4 to ^8.1.3


*For a more detailed changelog have a look at:* http://github.com/process-engine/ci_tools/releases/tag/v3.1.0-alpha.10
```

Woher das Kommatar in der mocha Zeile kommt weiß ich im Moment noch nicht. Ich konnte jetzt leider nicht mehr weiter debuggen da `API rate limit exceeded for 91.9.121.4. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)`.

## Issues

PR: #84 

## How to test the changes

Branch auschecken und `node dist/ci_tools.js publish-releasenotes-on-slack --addVersionChange node-fetch --addVersionChange mocha` ausführen. 
